### PR TITLE
#19-카카오 로그인 연동 구현.

### DIFF
--- a/app/src/main/java/com/teamdonut/eatto/ETApplication.java
+++ b/app/src/main/java/com/teamdonut/eatto/ETApplication.java
@@ -3,14 +3,36 @@ package com.teamdonut.eatto;
 import android.app.Application;
 import com.bumptech.glide.Glide;
 import com.facebook.stetho.Stetho;
+import com.kakao.auth.KakaoSDK;
+import com.teamdonut.eatto.util.kakao.KakaoSDKAdapter;
 
 public class ETApplication extends Application {
+
+    private static volatile ETApplication instance = null;
+
+    public static ETApplication getETApplicationContext() {
+        if (instance == null) {
+            throw new IllegalStateException("this application does not inherit ETApplication.");
+        }
+        return instance;
+    }
 
     @Override
     public void onCreate() {
         super.onCreate();
+        instance = this;
 
         Glide.with(this);
         Stetho.initializeWithDefaults(this);
+
+        KakaoSDK.init(new KakaoSDKAdapter());
     }
+
+    @Override
+    public void onTerminate() {
+        super.onTerminate();
+        instance = null;
+    }
+
+
 }

--- a/app/src/main/java/com/teamdonut/eatto/ui/login/LoginActivity.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/login/LoginActivity.java
@@ -1,0 +1,63 @@
+package com.teamdonut.eatto.ui.login;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.databinding.DataBindingUtil;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.kakao.auth.Session;
+import com.teamdonut.eatto.R;
+import com.teamdonut.eatto.databinding.LoginActivityBinding;
+import com.teamdonut.eatto.ui.main.MainActivity;
+import com.teamdonut.eatto.util.ActivityUtils;
+import com.teamdonut.eatto.util.kakao.LoginSessionCallback;
+
+public class LoginActivity extends AppCompatActivity implements LoginNavigator {
+
+    private LoginActivityBinding binding;
+    private LoginSessionCallback callback;
+
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        //로그인 결과를 세션이 받음.
+        if (Session.getCurrentSession().handleActivityResult(requestCode, resultCode, data)) {
+            return;
+        }
+
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = DataBindingUtil.setContentView(this, R.layout.login_activity);
+
+        initCallback();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        Session.getCurrentSession().removeCallback(callback);
+    }
+
+    private void initCallback() {
+        callback = new LoginSessionCallback(this);
+        Session.getCurrentSession().addCallback(callback);
+    }
+
+
+    @Override
+    public void redirectLoginActivity() {
+        ActivityUtils.redirectLoginActivity(this);
+    }
+
+    @Override
+    public void redirectMainActivity() {
+        ActivityUtils.redirectMainActivity(this);
+    }
+}

--- a/app/src/main/java/com/teamdonut/eatto/ui/login/LoginNavigator.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/login/LoginNavigator.java
@@ -1,0 +1,8 @@
+package com.teamdonut.eatto.ui.login;
+
+public interface LoginNavigator {
+
+    void redirectLoginActivity();
+
+    void redirectMainActivity();
+}

--- a/app/src/main/java/com/teamdonut/eatto/util/ActivityUtils.java
+++ b/app/src/main/java/com/teamdonut/eatto/util/ActivityUtils.java
@@ -1,10 +1,17 @@
 package com.teamdonut.eatto.util;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import com.teamdonut.eatto.ui.login.LoginActivity;
+
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+import com.teamdonut.eatto.ui.main.MainActivity;
 
 import static androidx.core.util.Preconditions.checkNotNull;
 
@@ -21,5 +28,17 @@ public class ActivityUtils {
         FragmentTransaction transaction = fragmentManager.beginTransaction();
         transaction.replace(frameId, fragment);
         transaction.commit();
+    }
+
+    public static void redirectLoginActivity(Activity activity) {
+        final Intent intent = new Intent(activity, LoginActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        activity.startActivity(intent);
+    }
+
+    public static void redirectMainActivity(Context context) {
+        final Intent intent = new Intent(context, MainActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        context.startActivity(intent);
     }
 }

--- a/app/src/main/java/com/teamdonut/eatto/util/kakao/KakaoSDKAdapter.java
+++ b/app/src/main/java/com/teamdonut/eatto/util/kakao/KakaoSDKAdapter.java
@@ -1,0 +1,42 @@
+package com.teamdonut.eatto.util.kakao;
+
+import com.kakao.auth.*;
+import com.teamdonut.eatto.ETApplication;
+
+public class KakaoSDKAdapter extends KakaoAdapter {
+
+    @Override
+    public IApplicationConfig getApplicationConfig() {
+        return ETApplication::getETApplicationContext;
+    }
+
+    @Override
+    public ISessionConfig getSessionConfig() {
+        return new ISessionConfig() {
+            @Override
+            public AuthType[] getAuthTypes() {
+                return new AuthType[]{AuthType.KAKAO_TALK};
+            }
+
+            @Override
+            public boolean isUsingWebviewTimer() {
+                return true;
+            }
+
+            @Override
+            public boolean isSecureMode() {
+                return false;
+            }
+
+            @Override
+            public ApprovalType getApprovalType() {
+                return ApprovalType.INDIVIDUAL;
+            }
+
+            @Override
+            public boolean isSaveFormData() {
+                return true;
+            }
+        };
+    }
+}

--- a/app/src/main/java/com/teamdonut/eatto/util/kakao/LoginSessionCallback.java
+++ b/app/src/main/java/com/teamdonut/eatto/util/kakao/LoginSessionCallback.java
@@ -1,0 +1,62 @@
+package com.teamdonut.eatto.util.kakao;
+
+import android.util.Log;
+
+import com.kakao.auth.ISessionCallback;
+import com.kakao.network.ErrorResult;
+import com.kakao.usermgmt.ApiErrorCode;
+import com.kakao.usermgmt.UserManagement;
+import com.kakao.usermgmt.callback.MeV2ResponseCallback;
+import com.kakao.usermgmt.response.MeV2Response;
+import com.kakao.util.exception.KakaoException;
+import com.kakao.util.helper.log.Logger;
+import com.teamdonut.eatto.ui.login.LoginNavigator;
+
+public class LoginSessionCallback implements ISessionCallback {
+
+    private LoginNavigator navigator;
+
+    public LoginSessionCallback(LoginNavigator navigator) {
+        this.navigator = navigator;
+    }
+
+    @Override
+    public void onSessionOpened() {
+        requestMe();
+    }
+
+    @Override
+    public void onSessionOpenFailed(KakaoException exception) {
+        if (exception != null) {
+            Logger.e(exception);
+        }
+    }
+
+    private void requestMe() {
+        UserManagement.getInstance().me(new MeV2ResponseCallback() {
+            @Override
+            public void onSessionClosed(ErrorResult errorResult) {
+                navigator.redirectLoginActivity();
+            }
+
+            @Override
+            public void onFailure(ErrorResult errorResult) {
+                Logger.d("failed to get user info. msg = $errorResult");
+
+                if (errorResult.getErrorCode() == ApiErrorCode.CLIENT_ERROR_CODE) {
+                    Logger.d("error failed.");
+                } else {
+                    navigator.redirectLoginActivity();
+                }
+            }
+
+            @Override
+            public void onSuccess(MeV2Response result) {
+                if (result != null) {
+                    //여기서 서버로 사용자의 정보를 보냄.
+                    navigator.redirectMainActivity();
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/res/layout/login_activity.xml
+++ b/app/src/main/res/layout/login_activity.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android = "http://schemas.android.com/apk/res/android"
+        xmlns:app = "http://schemas.android.com/apk/res-auto"
+        xmlns:tools = "http://schemas.android.com/tools"
+        android:layout_width = "match_parent"
+        android:layout_height = "match_parent"
+        tools:context = ".ui.login.LoginActivity">
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id = "@+id/gl_start"
+            android:layout_width = "wrap_content"
+            android:layout_height = "wrap_content"
+            android:orientation = "vertical"
+            app:layout_constraintGuide_percent = "0.1" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id = "@+id/gl_end"
+            android:layout_width = "wrap_content"
+            android:layout_height = "wrap_content"
+            android:orientation = "vertical"
+            app:layout_constraintGuide_percent = "0.9" />
+
+        <com.kakao.usermgmt.LoginButton
+            android:id = "@+id/btn_login"
+            android:layout_width = "0dp"
+            android:layout_height = "wrap_content"
+            app:layout_constraintBottom_toBottomOf = "parent"
+            app:layout_constraintEnd_toEndOf = "@+id/gl_end"
+            app:layout_constraintStart_toStartOf = "@+id/gl_start"
+            app:layout_constraintTop_toTopOf = "parent"
+            app:layout_constraintVertical_bias = "0.9" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour
* `ActivityUtils`에 로그인, 메인 화면으로 이동하는 메소드를 추가했습니다.
* KakaoSDKAdapter 클래스를 생성해 디폴트 설정 값을 변경했습니다.
* `LoginSessionCallback` 클래스를 생성해 사용자 정보를 받아오는 로직을 구현했습니다.

### Other information (e.g. related issues)
* 사용자의 세션이 유효한지의 여부는 추후에 `SplashActivity`를 추가해 검사할 예정입니다.
* 젠킨스 빌드 에러는 카카오 앱 키 파일이 gitignore에 추가되어 그렇습니다.

resolved #19