### PR TITLE
#114-로그인 Session 유효 검사 체크 방법 변경.

### DIFF
--- a/app/src/main/java/com/teamdonut/eatto/ui/splash/SplashActivity.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/splash/SplashActivity.java
@@ -3,8 +3,14 @@ package com.teamdonut.eatto.ui.splash;
 import android.Manifest;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
+
 import androidx.appcompat.app.AppCompatActivity;
+
+import com.kakao.auth.ISessionCallback;
 import com.kakao.auth.Session;
+import com.kakao.util.exception.KakaoException;
+import com.kakao.util.helper.log.Logger;
 import com.teamdonut.eatto.R;
 import com.teamdonut.eatto.common.util.ActivityUtils;
 import com.teamdonut.eatto.common.util.GpsModule;
@@ -15,14 +21,37 @@ import java.lang.ref.WeakReference;
 public class SplashActivity extends AppCompatActivity {
 
     private final int SPLASH_TIME = 2000;
+    private ISessionCallback mCallback = new ISessionCallback() {
+        @Override
+        public void onSessionOpened() {
+
+            ActivityUtils.redirectMainActivity(SplashActivity.this);
+        }
+
+        @Override
+        public void onSessionOpenFailed(KakaoException exception) {
+            if (exception != null) {
+                Logger.e(exception);
+            }
+        }
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.splash_activity);
 
+        Session.getCurrentSession().addCallback(mCallback);
+
         requestLocationPermission();
     }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        Session.getCurrentSession().removeCallback(mCallback);
+    }
+
 
     private void requestLocationPermission() {
         TedRx2Permission.with(this)
@@ -48,10 +77,9 @@ public class SplashActivity extends AppCompatActivity {
      */
     private void checkLoginSessionIsValid() {
         new Handler().postDelayed(() -> {
-            if (Session.getCurrentSession().isOpened()) {
-                ActivityUtils.redirectMainActivity(this);
-            } else if (Session.getCurrentSession().isClosed()) {
+            if (!Session.getCurrentSession().checkAndImplicitOpen()) {
                 ActivityUtils.redirectLoginActivity(this);
+                finish();
             }
         }, SPLASH_TIME);
     }

--- a/app/src/main/java/com/teamdonut/eatto/ui/splash/SplashActivity.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/splash/SplashActivity.java
@@ -3,9 +3,6 @@ package com.teamdonut.eatto.ui.splash;
 import android.Manifest;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.Log;
-
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.kakao.auth.ISessionCallback;
 import com.kakao.auth.Session;
@@ -18,13 +15,14 @@ import com.tedpark.tedpermission.rx2.TedRx2Permission;
 
 import java.lang.ref.WeakReference;
 
+import androidx.appcompat.app.AppCompatActivity;
+
 public class SplashActivity extends AppCompatActivity {
 
     private final int SPLASH_TIME = 2000;
     private ISessionCallback mCallback = new ISessionCallback() {
         @Override
         public void onSessionOpened() {
-
             ActivityUtils.redirectMainActivity(SplashActivity.this);
         }
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
* 스플래쉬 화면에서 `Session.getCurrentSesson().isOpened()`로 세션의 유효 여부를 체크하게 되어있습니다.
* 이 경우, 일정 시간이 지나면 해당 부분을 통과하지 못하는 이슈가 있습니다.

### New behaviour
* `checkAndImplicitOpen()` 메소드를 사용해 검사하는 방법으로 수정했습니다.
* 1. 세션이 닫힌 상태가 아니면서, refreshToken으로 갱신이 가능한지 검사합니다.
* 2. `SplashActivity`에 콜백을 등록해, 세션이 열린상태면 메인 화면으로 이동합니다.
유효하지 않으면 로그인 화면으로 이동합니다.

### Other information (e.g. related issues)

resolved #114