### PR TITLE
#115-RxBus를 쓰지 않고 startActivityForResult() 와 onActivityResult 로 처리되지 않았던 문제 해결법

### DIFF
--- a/app/src/main/java/com/teamdonut/eatto/ui/board/BoardAddActivity.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/board/BoardAddActivity.java
@@ -158,13 +158,13 @@ public class BoardAddActivity extends AppCompatActivity implements BoardNavigato
 
         if (Strings.isEmptyOrWhitespace(binding.etInputContent.getText().toString())) {
             board.setContent("");
-        }else {
+        } else {
             board.setContent(binding.etInputContent.getText().toString());
         }
 
         if (Strings.isEmptyOrWhitespace(binding.etInputBudget.getText().toString())) {
             board.setBudget("0");
-        }else {
+        } else {
             board.setBudget(binding.etInputBudget.getText().toString());
         }
 
@@ -185,10 +185,7 @@ public class BoardAddActivity extends AppCompatActivity implements BoardNavigato
                     result.subscribeOn(Schedulers.io())
                             .observeOn(AndroidSchedulers.mainThread())
                             .subscribe((data) -> {
-                                        Log.d("result", data.toString());
-
-                                        RxBus.getInstance().sendBus(new String(getResources().getText(R.string.board_add_end).toString()));
-
+                                        setResult(RESULT_OK);
                                         finish();
                                     }, (e) -> {
                                         e.printStackTrace();
@@ -206,7 +203,6 @@ public class BoardAddActivity extends AppCompatActivity implements BoardNavigato
     @Override
     protected void onDestroy() {
         compositeDisposable.clear();
-        RxBus.setInstanceToNull();
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/teamdonut/eatto/ui/board/BoardFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/board/BoardFragment.java
@@ -17,6 +17,7 @@ import androidx.fragment.app.Fragment;
 public class BoardFragment extends Fragment implements BoardNavigator {
     private BoardFragmentBinding binding;
     private BoardViewModel mViewModel;
+    private final int BOARD_ADD_REQUEST = 100;
 
     public static BoardFragment newInstance() {
         return new BoardFragment();
@@ -40,6 +41,6 @@ public class BoardFragment extends Fragment implements BoardNavigator {
     @Override
     public void addBoard() {
         Intent intent = new Intent(getContext(), BoardAddActivity.class);
-        startActivity(intent);
+        getActivity().startActivityForResult(intent, BOARD_ADD_REQUEST);
     }
 }

--- a/app/src/main/java/com/teamdonut/eatto/ui/main/MainActivity.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/main/MainActivity.java
@@ -2,6 +2,7 @@ package com.teamdonut.eatto.ui.main;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 
 import com.google.android.material.snackbar.Snackbar;
 import com.teamdonut.eatto.R;
@@ -48,10 +49,16 @@ public class MainActivity extends AppCompatActivity implements MainNavigator {
     @Override
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         if (resultCode == RESULT_OK) {
-            if (requestCode == BOARD_ADD_REQUEST) {
-                Snackbar.make(binding.flMain, getResources().getText(R.string.board_add_success).toString(), Snackbar.LENGTH_SHORT).show();
+            switch (requestCode) {
+                case BOARD_ADD_REQUEST:
+                    showSnackBar(binding.flMain, R.string.board_add_success);
+                    break;
             }
         }
+    }
+
+    public void showSnackBar(View view, int resId) {
+        Snackbar.make(view, getResources().getText(resId).toString(), Snackbar.LENGTH_SHORT).show();
     }
 
 }

--- a/app/src/main/java/com/teamdonut/eatto/ui/main/MainActivity.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/main/MainActivity.java
@@ -1,15 +1,15 @@
 package com.teamdonut.eatto.ui.main;
 
+import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 
 import com.google.android.material.snackbar.Snackbar;
 import com.teamdonut.eatto.R;
-import com.teamdonut.eatto.databinding.MainActivityBinding;
 import com.teamdonut.eatto.common.util.ActivityUtils;
-import com.teamdonut.eatto.common.RxBus;
+import com.teamdonut.eatto.databinding.MainActivityBinding;
 import com.teamdonut.eatto.ui.home.HomeFragment;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
@@ -18,6 +18,7 @@ public class MainActivity extends AppCompatActivity implements MainNavigator {
 
     private MainActivityBinding binding;
     private MainViewModel mViewModel = new MainViewModel(this);
+    private final int BOARD_ADD_REQUEST = 100;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -37,22 +38,20 @@ public class MainActivity extends AppCompatActivity implements MainNavigator {
     @Override
     protected void onResume() {
         super.onResume();
-        RxBus.getInstance().getBus()
-                .subscribe(result -> {
-
-                    if (result instanceof String) {
-                        if (result.toString().equals(getResources().getText(R.string.board_add_end).toString())) {
-                            Log.d("result test", result.toString());
-                            Snackbar.make(binding.flMain, R.string.main_snack_bar, Snackbar.LENGTH_SHORT).show();
-                        }
-                    }
-
-                }, err -> err.printStackTrace());
     }
 
     @Override
     protected void onDestroy() {
-        RxBus.setInstanceToNull();
         super.onDestroy();
     }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        if (resultCode == RESULT_OK) {
+            if (requestCode == BOARD_ADD_REQUEST) {
+                Snackbar.make(binding.flMain, getResources().getText(R.string.board_add_success).toString(), Snackbar.LENGTH_SHORT).show();
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
@@ -32,6 +32,7 @@ public class MapFragment extends Fragment implements MapNavigator {
 
     private BottomSheetBehavior bottomSheetBehavior;
     private MapView mapView;
+    private final int BOARD_ADD_REQUEST = 100;
     public static MapFragment newInstance() {
         Bundle args = new Bundle();
 
@@ -97,6 +98,6 @@ public class MapFragment extends Fragment implements MapNavigator {
     @Override
     public void addBoard() {
         Intent intent = new Intent(getContext(), BoardAddActivity.class);
-        startActivity(intent);
+        getActivity().startActivityForResult(intent, BOARD_ADD_REQUEST);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <!-- Board_Add -->
     <string name="board_add_snack_bar">모두 입력해주세요</string>
     <string name="board_add_end">BOARD_ADD_END</string>
+    <string name="board_add_success">게시글 등록 완료</string>
 
     <!-- Board_detail -->
     <string name="board_detail_btn_input_comment">작성</string>


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour
- onActivityResult가 호출되지 않는 문제 발생

### New behaviour
- Fragment에서 호출시 getActivity().startActivityForResult로 호출

### Other information (e.g. related issues)

resolved #115