### PR TITLE
#78-Add Bottomsheet behavior callback

### DIFF
--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
@@ -48,12 +48,24 @@ public class MapFragment extends Fragment implements MapNavigator {
         binding.setViewmodel(mViewModel);
         binding.setBottomsheetviewmodel(mBottomSheetViewModel);
 
-        bottomSheetBehavior = BottomSheetBehavior.from(binding.mapBottomSheet.clMapBottomSheet);
+        return binding.getRoot();
+    }
 
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        initMapView();
+        initBottomSheetBehavior();
+    }
+
+    private void initMapView() {
         //레이아웃에 지도 추가
         mapView = new MapView(getActivity());
         binding.flMapView.addView(mapView);
-        return binding.getRoot();
+    }
+
+    private void initBottomSheetBehavior() {
     }
 
     @Override

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
@@ -34,12 +34,9 @@ public class MapFragment extends Fragment implements MapNavigator {
     private BottomSheetBehavior bottomSheetBehavior;
     private MapView mapView;
     private final int BOARD_ADD_REQUEST = 100;
-    public static MapFragment newInstance() {
-        Bundle args = new Bundle();
 
-        MapFragment fragment = new MapFragment();
-        fragment.setArguments(args);
-        return fragment;
+    public static MapFragment newInstance() {
+        return new MapFragment();
     }
 
     @Override

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
@@ -138,7 +138,7 @@ public class MapFragment extends Fragment implements MapNavigator {
     }
 
     @Override
-    public void goToSearch() {
+    public void goToMapSearch() {
         Intent intent = new Intent(getActivity(), MapSearchActivity.class);
         startActivity(intent);
     }

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
@@ -6,8 +6,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import com.teamdonut.eatto.ui.board.BoardAddActivity;
-import com.teamdonut.eatto.ui.board.BoardDetailActivity;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
@@ -16,6 +15,7 @@ import com.teamdonut.eatto.R;
 import com.teamdonut.eatto.common.util.ActivityUtils;
 import com.teamdonut.eatto.common.util.GpsModule;
 import com.teamdonut.eatto.databinding.MapFragmentBinding;
+import com.teamdonut.eatto.ui.board.BoardAddActivity;
 import com.teamdonut.eatto.ui.map.bottomsheet.MapBottomSheetViewModel;
 import com.teamdonut.eatto.ui.map.search.MapSearchActivity;
 import com.tedpark.tedpermission.rx2.TedRx2Permission;
@@ -67,6 +67,30 @@ public class MapFragment extends Fragment implements MapNavigator {
     }
 
     private void initBottomSheetBehavior() {
+        bottomSheetBehavior = BottomSheetBehavior.from(binding.mapBottomSheet.clMapBottomSheet);
+        bottomSheetBehavior.setBottomSheetCallback(new BottomSheetBehavior.BottomSheetCallback() {
+            @Override
+            public void onStateChanged(@NonNull View bottomSheet, int newState) {
+                switch (newState) {
+                    case BottomSheetBehavior.STATE_EXPANDED: {
+                        mBottomSheetViewModel.isSheetExpanded.set(true);
+                        break;
+                    }
+                    case BottomSheetBehavior.STATE_COLLAPSED: {
+                        mBottomSheetViewModel.isSheetExpanded.set(false);
+                        break;
+                    }
+                    default: {
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            public void onSlide(@NonNull View bottomSheet, float slideOffset) {
+                //nothing to do.
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
@@ -90,17 +90,18 @@ public class MapFragment extends Fragment implements MapNavigator {
     public void setMyPosition() {
         float latitude = Float.valueOf(ActivityUtils.getStrValueSharedPreferences(getActivity(), "gps", "latitude"));
         float longitude = Float.valueOf(ActivityUtils.getStrValueSharedPreferences(getActivity(), "gps", "longitude"));
-        mapView.setMapCenterPointAndZoomLevel(MapPoint.mapPointWithGeoCoord(latitude, longitude),2,true);
-    }
-  
-    @Override
-    public void addBoard() {
-        Intent intent = new Intent(getContext(), BoardAddActivity.class);
-        getActivity().startActivityForResult(intent, BOARD_ADD_REQUEST);
+
+        mapView.setMapCenterPointAndZoomLevel(MapPoint.mapPointWithGeoCoord(latitude, longitude), 2, true);
     }
 
     @Override
-    public void startSearchActivity() {
+    public void goToBoardWrite() {
+        Intent intent = new Intent(getContext(), BoardAddActivity.class);
+        startActivityForResult(intent, BOARD_ADD_REQUEST);
+    }
+
+    @Override
+    public void goToSearch() {
         Intent intent = new Intent(getActivity(), MapSearchActivity.class);
         startActivity(intent);
     }

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
@@ -132,7 +132,7 @@ public class MapFragment extends Fragment implements MapNavigator {
     }
 
     @Override
-    public void goToBoardWrite() {
+    public void goToBoardAdd() {
         Intent intent = new Intent(getContext(), BoardAddActivity.class);
         startActivityForResult(intent, BOARD_ADD_REQUEST);
     }

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapFragment.java
@@ -40,11 +40,12 @@ public class MapFragment extends Fragment implements MapNavigator {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        // Inflate the layout for this fragment
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.map_fragment, container, false);
+
         mViewModel = new MapViewModel(this);
         mBottomSheetViewModel = new MapBottomSheetViewModel(this);
+
         binding.setViewmodel(mViewModel);
         binding.setBottomsheetviewmodel(mBottomSheetViewModel);
 

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapNavigator.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapNavigator.java
@@ -5,6 +5,6 @@ public interface MapNavigator {
     void setBottomSheetExpand(Boolean isExpand);
     void startLocationUpdates();
     void setMyPosition();
-    void goToBoardWrite();
+    void goToBoardAdd();
     void goToSearch();
 }

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapNavigator.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapNavigator.java
@@ -6,5 +6,5 @@ public interface MapNavigator {
     void startLocationUpdates();
     void setMyPosition();
     void goToBoardAdd();
-    void goToSearch();
+    void goToMapSearch();
 }

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapNavigator.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapNavigator.java
@@ -2,9 +2,9 @@ package com.teamdonut.eatto.ui.map;
 
 public interface MapNavigator {
 
-    void setBottomSheetExpand(Boolean state);
+    void setBottomSheetExpand(Boolean isExpand);
     void startLocationUpdates();
     void setMyPosition();
-    void addBoard();
-    void startSearchActivity();
+    void goToBoardWrite();
+    void goToSearch();
 }

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapViewModel.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapViewModel.java
@@ -16,13 +16,13 @@ public class MapViewModel {
 
     //검색 버튼 리스너
     public void onSearchClick() {
-        mNavigator.startSearchActivity();
+        mNavigator.goToSearch();
     }
 
     //게시물 추가 리스너
     public void onClickBoardAdd() {
         if (mNavigator != null) {
-            mNavigator.addBoard();
+            mNavigator.goToBoardWrite();
         }
     }
 

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapViewModel.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapViewModel.java
@@ -22,7 +22,7 @@ public class MapViewModel {
     //게시물 추가 리스너
     public void onClickBoardAdd() {
         if (mNavigator != null) {
-            mNavigator.goToBoardWrite();
+            mNavigator.goToBoardAdd();
         }
     }
 

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/MapViewModel.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/MapViewModel.java
@@ -16,7 +16,7 @@ public class MapViewModel {
 
     //검색 버튼 리스너
     public void onSearchClick() {
-        mNavigator.goToSearch();
+        mNavigator.goToMapSearch();
     }
 
     //게시물 추가 리스너

--- a/app/src/main/java/com/teamdonut/eatto/ui/map/bottomsheet/MapBottomSheetViewModel.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/map/bottomsheet/MapBottomSheetViewModel.java
@@ -1,32 +1,23 @@
 package com.teamdonut.eatto.ui.map.bottomsheet;
 
-import com.teamdonut.eatto.ui.map.MapNavigator;
-
-import org.jetbrains.annotations.NotNull;
-
 import androidx.databinding.ObservableBoolean;
+import com.teamdonut.eatto.ui.map.MapNavigator;
 
 public class MapBottomSheetViewModel {
 
-    @NotNull
+    private MapNavigator mNavigator;
     public final ObservableBoolean isSheetExpanded = new ObservableBoolean(false);
 
-    private MapNavigator navigator;
-
-
     public MapBottomSheetViewModel(MapNavigator navigator) {
-        this.navigator = navigator;
+        this.mNavigator = navigator;
     }
 
     public void onScrollButtonClick() {
         if (!isSheetExpanded.get()) {
-            navigator.setBottomSheetExpand(true);
-            isSheetExpanded.set(true);
+            mNavigator.setBottomSheetExpand(true);
         } else {
-            navigator.setBottomSheetExpand(false);
-            isSheetExpanded.set(false);
+            mNavigator.setBottomSheetExpand(false);
         }
     }
-
 }
 

--- a/app/src/main/res/layout/map_bottom_sheet.xml
+++ b/app/src/main/res/layout/map_bottom_sheet.xml
@@ -27,20 +27,20 @@
             android:text="@{viewmodel.isSheetExpanded ? @string/map_sheet_show_title(5) : @string/map_sheet_hide_title}"
             android:textColor="@color/colorHungryBlack"
             android:textSize="14sp"
-            app:layout_constraintEnd_toStartOf="@+id/ib_down"
+            app:layout_constraintEnd_toStartOf="@+id/ib_direction"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="이 지역 혼밥러 5명" />
 
         <ImageButton
-            android:id="@+id/ib_down"
+            android:id="@+id/ib_direction"
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:background="#E6FFFFFF"
             android:onClick="@{() ->viewmodel.onScrollButtonClick()}"
             android:padding="@dimen/space_img_btn_padding"
             android:src="@{viewmodel.isSheetExpanded ? @drawable/ic_arrow_down_32dp : @drawable/ic_arrow_up_32dp}"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_sheet_title"
+            app:layout_constraintBottom_toBottomOf="@id/tv_sheet_title"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -51,7 +51,7 @@
             android:layout_marginTop="@dimen/space_medium_margin"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_sheet_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_sheet_title" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
* `BottomSheet`의 화살표 버튼을 클릭하면 텍스트와 이미지가 상황에 맞게 변하지만,
슬라이드하는 경우 변하지 않는 이슈가 있습니다.

### New behaviour
* `BottomSheetBehavior callback`을 등록해 버튼을 클릭할 경우와 슬라이드할 경우에
텍스트와 이미지가 상황에 맞게 변하도록 구현했습니다.

* 뷰 초기화 관련 메소드 호출 시점을 Acitvity의 creater가 완료되는 시점인 `onActivityCreated()`로 변경했습니다.
[프래그먼트의 onCreateView vs onActivityCreated](https://stackoverflow.com/questions/28929637/difference-and-uses-of-oncreate-oncreateview-and-onactivitycreated-in-fra)


### Other information (e.g. related issues)

resolved #78