### PR TITLE
#158-마이페이지 수정 후 뒤로가기 기능 구현.

### DIFF
--- a/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditActivity.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditActivity.java
@@ -15,6 +15,8 @@ import com.tedpark.tedpermission.rx2.TedRx2Permission;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.databinding.DataBindingUtil;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProviders;
 import gun0912.tedbottompicker.TedBottomPicker;
 
 public class MyPageEditActivity extends AppCompatActivity implements MyPageEditNavigator {
@@ -26,17 +28,18 @@ public class MyPageEditActivity extends AppCompatActivity implements MyPageEditN
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = DataBindingUtil.setContentView(this, R.layout.mypage_edit_activity);
-        mViewModel = new MyPageEditViewModel(this);
+        mViewModel = ViewModelProviders.of(this).get(MyPageEditViewModel.class);
+        mViewModel.setmNavigator(this);
+
+        mViewModel.getIsSubmitted().observe(this, isSubmitted -> {
+                    if (isSubmitted) {
+                        finish();
+                    }
+                });
 
         binding.setViewmodel(mViewModel);
 
         initToolbar();
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        mViewModel.onDestroyViewModel();
     }
 
     @Override

--- a/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditActivity.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditActivity.java
@@ -28,18 +28,22 @@ public class MyPageEditActivity extends AppCompatActivity implements MyPageEditN
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = DataBindingUtil.setContentView(this, R.layout.mypage_edit_activity);
+
         mViewModel = ViewModelProviders.of(this).get(MyPageEditViewModel.class);
         mViewModel.setmNavigator(this);
 
-        mViewModel.getIsSubmitted().observe(this, isSubmitted -> {
-                    if (isSubmitted) {
-                        finish();
-                    }
-                });
-
         binding.setViewmodel(mViewModel);
 
+        initObserver();
         initToolbar();
+    }
+
+    private void initObserver() {
+        mViewModel.getIsSubmitted().observe(this, isSubmitted -> {
+            if (isSubmitted) {
+                finish();
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditViewModel.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditViewModel.java
@@ -17,8 +17,6 @@ import io.realm.Realm;
 
 public class MyPageEditViewModel extends ViewModel {
 
-    private static final String TAG = "MyPageEditViewwModel";
-
     private MyPageEditNavigator mNavigator;
 
     private UserAPI service = ServiceGenerator.createService(UserAPI.class, ServiceGenerator.BASE);
@@ -41,7 +39,6 @@ public class MyPageEditViewModel extends ViewModel {
                         .observeOn(AndroidSchedulers.mainThread())
                         .doAfterSuccess(data -> {
                             isSubmitted.setValue(true);
-                            Log.d(TAG, "isSubmitted is " + isSubmitted.getValue());
                         } )
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(data-> {

--- a/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditViewModel.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditViewModel.java
@@ -1,18 +1,23 @@
 package com.teamdonut.eatto.ui.mypage;
 
+import android.util.Log;
+
 import com.google.android.gms.common.util.Strings;
 import com.teamdonut.eatto.data.User;
 import com.teamdonut.eatto.model.ServiceGenerator;
 import com.teamdonut.eatto.model.UserAPI;
 
-import androidx.databinding.BaseObservable;
 import androidx.databinding.ObservableInt;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
 import io.realm.Realm;
 
-public class MyPageEditViewModel extends BaseObservable {
+public class MyPageEditViewModel extends ViewModel {
+
+    private static final String TAG = "MyPageEditViewwModel";
 
     private MyPageEditNavigator mNavigator;
 
@@ -26,14 +31,18 @@ public class MyPageEditViewModel extends BaseObservable {
     public final ObservableInt userSex = new ObservableInt(user.getSex());
     public final ObservableInt userAge = new ObservableInt(user.getAge());
 
-    public MyPageEditViewModel(MyPageEditNavigator navigator) {
-        this.mNavigator = navigator;
-    }
+    //whether user info is submitted or not.
+    private MutableLiveData<Boolean> isSubmitted = new MutableLiveData<>();
 
     public void submitUserInformation() {
         disposable.add(new CompositeDisposable(
                 service.postUserInfo(user)
                         .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .doAfterSuccess(data -> {
+                            isSubmitted.setValue(true);
+                            Log.d(TAG, "isSubmitted is " + isSubmitted.getValue());
+                        } )
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(data-> {
                                     //print response log
@@ -80,12 +89,22 @@ public class MyPageEditViewModel extends BaseObservable {
         mNavigator.selectPhoto();
     }
 
-    public void onDestroyViewModel() {
-        realm.close();
-        disposable.dispose();
-    }
-
     public User getUser() {
         return user;
+    }
+
+    @Override
+    protected void onCleared() {
+        realm.close();
+        disposable.dispose();
+        super.onCleared();
+    }
+
+    public MutableLiveData<Boolean> getIsSubmitted() {
+        return isSubmitted;
+    }
+
+    public void setmNavigator(MyPageEditNavigator mNavigator) {
+        this.mNavigator = mNavigator;
     }
 }

--- a/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditViewModel.java
+++ b/app/src/main/java/com/teamdonut/eatto/ui/mypage/MyPageEditViewModel.java
@@ -93,7 +93,7 @@ public class MyPageEditViewModel extends ViewModel {
     @Override
     protected void onCleared() {
         realm.close();
-        disposable.dispose();
+        disposables.dispose();
         super.onCleared();
     }
 


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour
* 마이페이지 수정화면에서 서버로 사용자의 정보 전송 후, 다시 마이페이지로 돌아가도록 구현했습니다.
* `ViewModel`을 상속받는 형태로 변경했습니다.
* LiveData를 사용했습니다.


### Other information (e.g. related issues)

resolved #158